### PR TITLE
Updated README prerequisites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Language Models (LLMs) on your local machine.
 ### Prerequisites
 
 1. Download and install [ollama CLI](https://ollama.ai/download).
+2. Download and install [yarn] (https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) and [node] (https://nodejs.org/en/download)
 
 ```bash
 ollama pull <model-name>


### PR DESCRIPTION
README doesn't clearly mention the dependencies on yarn (and especially node). Added those to make it easier for get started. 