### PR TITLE
Fixed the CSS Bug where STRONG tags don't show correctly in dark mode, documented in Issues

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -16,3 +16,8 @@
 .slide-leave-from {
   transform: translateX(0);
 }
+
+.prose :where(strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: #d2d2d2;
+  font-weight: 600;
+}


### PR DESCRIPTION
Added some conditions to the stylesheet that prevents the STRONG tag from being illegible in dark mode.