### PR TITLE
Allow upload images for multimodal chats

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,34 +3,14 @@ import Sidebar from './components/Sidebar.vue'
 import ChatInput from './components/ChatInput.vue'
 import ChatMessages from './components/ChatMessages.vue'
 import Settings from './components/Settings.vue'
-import ModelSelector from './components/ModelSelector.vue'
 import { isDarkMode, isSettingsOpen } from './services/appConfig.ts'
 import { onMounted, ref } from 'vue'
 import { useAI } from './services/useAI.ts'
 import { useChats } from './services/chat.ts'
-import TextInput from './components/Inputs/TextInput.vue'
+import { useImageDropzone } from './services/useImageDropzone.ts'
 
 const { refreshModels, availableModels } = useAI()
-const { activeChat, renameChat, switchModel, initialize } = useChats()
-const isEditingChatName = ref(false)
-const editedChatName = ref('')
-
-const startEditing = () => {
-  isEditingChatName.value = true
-  editedChatName.value = activeChat.value?.name || ''
-}
-
-const cancelEditing = () => {
-  isEditingChatName.value = false
-  editedChatName.value = ''
-}
-
-const confirmRename = () => {
-  if (activeChat.value && editedChatName.value) {
-    renameChat(editedChatName.value)
-    isEditingChatName.value = false
-  }
-}
+const { activeChat, switchModel, initialize } = useChats()
 
 onMounted(() => {
   refreshModels().then(async () => {
@@ -40,6 +20,8 @@ onMounted(() => {
     }
   })
 })
+const dropZoneRef = ref<HTMLDivElement>()
+const { dropZoneIsActive } = useImageDropzone(dropZoneRef)
 </script>
 
 <template>
@@ -49,37 +31,15 @@ onMounted(() => {
     >
       <Sidebar />
 
-      <div class="mx-auto flex h-[100vh] w-full flex-col">
-        <div class="mx-auto flex h-[100vh] w-full max-w-7xl flex-col gap-4 px-4 pb-4">
-          <div
-            class="flex w-full flex-row items-center justify-center gap-4 rounded-b-xl bg-zinc-200 px-4 py-2 dark:bg-zinc-700"
+      <div class="mx-auto h-[100dvh] w-full relative">
+        <div
+          class="mx-auto flex h-[100dvh] w-full max-w-7xl flex-col gap-4 px-4 pb-4 border-4"
+          :class="{
+            'border-opacity-90 rounded border-dashed border-blue-800': dropZoneIsActive,
+            'border-transparent': !dropZoneIsActive
+          }"
+          ref="dropZoneRef"
           >
-            <div class="mr-auto flex h-full items-center" v-if="activeChat">
-              <div>
-                <div v-if="isEditingChatName">
-                  <TextInput
-                    autofocus
-                    v-model="editedChatName"
-                    @keyup.enter="confirmRename"
-                    @keyup.esc="cancelEditing"
-                    @blur="cancelEditing"
-                  />
-                </div>
-
-                <button
-                  type="button"
-                  class="block h-full rounded border-none p-2 text-zinc-700 decoration-gray-400 decoration-dashed outline-none hover:underline focus:ring-2 focus:ring-blue-600 dark:text-zinc-100 dark:focus:ring-blue-600"
-                  v-else
-                  @click.prevent="startEditing"
-                >
-                  {{ activeChat.name }}
-                </button>
-              </div>
-            </div>
-
-            <ModelSelector />
-          </div>
-
           <ChatMessages />
           <ChatInput />
         </div>

--- a/src/components/ChatImageModal.vue
+++ b/src/components/ChatImageModal.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { onClickOutside } from '@vueuse/core';
+import { inject, Ref, computed, ref } from 'vue';
+import { IconPhoto } from '@tabler/icons-vue'
+import { INJECT_IMAGE_KEY } from '../services/useImageDropzone';
+
+const chatImageFileInjected = inject<Ref<File | null>>(INJECT_IMAGE_KEY);
+const chatImageFileName = computed(() => chatImageFileInjected?.value?.name)
+
+const imageAsBase64 = computed(() => {
+  if (!chatImageFileInjected?.value || !dialogWasOpen.value) {
+    return ''
+  }
+  return URL.createObjectURL(chatImageFileInjected.value)
+})
+
+function fileSizeToHumanReadable(size) {
+  if (size === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const i = Math.floor(Math.log(size) / Math.log(k));
+  return parseFloat((size / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+const imageSize = computed(() => {
+  return fileSizeToHumanReadable(chatImageFileInjected?.value?.size)
+})
+
+
+const dialogElement = ref<HTMLDialogElement | null>(null)
+const dialogContainerElement = ref<HTMLDivElement | null>(null)
+const dialogWasOpen = ref(false)
+const openDialog = () => {
+  dialogElement.value?.showModal()
+  dialogWasOpen.value = true
+}
+onClickOutside(dialogContainerElement, () => dialogElement.value?.close())
+</script>
+
+<template>
+  <button v-if="chatImageFileInjected" @click="openDialog" type="button" :title="chatImageFileName" class="
+        absolute
+        flex
+        items-center justify-center
+        bottom-2 right-14
+        h-10 w-10
+        rounded-lg
+        text-zinc-200 text-sm font-medium 
+        sm:text-base
+        dark:bg-teal-600"
+    >
+    <IconPhoto :size="20" />
+  </button>
+  <dialog ref="dialogElement">
+    <div ref="dialogContainerElement">
+      <div class="px-4 py-3 flex justify-between dark:bg-zinc-800 dark:text-zinc-200">
+        <h5>{{ chatImageFileName }}</h5>
+        <span>{{ imageSize }}</span>
+      </div>
+      <img :src="imageAsBase64" class="w-full max-h-[70dvh] object-cover" alt="Uploaded image" />
+    </div>
+  </dialog>
+</template>
+

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { useTextareaAutosize } from '@vueuse/core'
 import { useChats } from '../services/chat.ts'
 import { IconPlayerStopFilled, IconSend, IconWhirl } from '@tabler/icons-vue'
+import ChatImageModal from './ChatImageModal.vue';
 
 const { textarea, input: userInput } = useTextareaAutosize({ input: '' })
 const { addUserMessage, abort, hasActiveChat } = useChats()
@@ -53,6 +54,7 @@ const onKeydown = (event: KeyboardEvent) => {
         placeholder="Enter your prompt"
         @keydown="onKeydown"
       ></textarea>
+      <ChatImageModal />
       <button
         type="submit"
         :disabled="isInputValid == false && isAiResponding == false"

--- a/src/components/Messages/UserMessage.vue
+++ b/src/components/Messages/UserMessage.vue
@@ -21,6 +21,12 @@ const { message } = defineProps<Props>()
         class="prose prose-base prose-zinc max-w-full prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-p:first:mt-0 prose-a:text-blue-600 prose-code:text-sm prose-pre:p-2 dark:text-zinc-100"
       >
         <Markdown :source="message.content" />
+         <img
+          v-if="message.image"
+          class="max-h-[70dvh]"
+          :src="'data:image/jpeg;base64,' + message.image"
+          alt="Uploaded image"
+        />
       </div>
     </div>
   </div>

--- a/src/components/ModelSelector.vue
+++ b/src/components/ModelSelector.vue
@@ -2,7 +2,8 @@
 import { IconRefresh } from '@tabler/icons-vue'
 import { useChats } from '../services/chat.ts'
 import { useAI } from '../services/useAI.ts'
-import { ref } from 'vue'
+import { ref, vModelDynamic } from 'vue'
+import { Model } from '../services/api.ts';
 
 const { activeChat, switchModel, hasMessages } = useChats()
 const { refreshModels, availableModels } = useAI()
@@ -24,11 +25,15 @@ const handleModelChange = (event: Event) => {
   console.log('switch', wip.value)
   switchModel(wip.value)
 }
+const modelAllowsVisionText = (model: Model) => {
+  const modelAllowsVision = model.details?.families?.includes('clip')
+  return modelAllowsVision ? '- w/vision' : ''
+}
 </script>
 
 <template>
-  <div class="flex flex-row text-zinc-800 dark:text-zinc-200">
-    <div class="inline-flex items-center gap-2">
+  <div class="flex flex-row w-full text-zinc-800 dark:text-zinc-200">
+    <div class="inline-flex w-full items-center gap-2">
       <select
         :disabled="hasMessages"
         :value="activeChat?.model"
@@ -37,7 +42,7 @@ const handleModelChange = (event: Event) => {
       >
         <option :value="undefined" disabled selected>Select a model</option>
         <option v-for="model in availableModels" :value="model.name">
-          {{ model.name }}
+          {{ model.name }} {{ modelAllowsVisionText(model) }}
         </option>
       </select>
 

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -2,6 +2,7 @@
 import { IconLayoutSidebarRightCollapse } from '@tabler/icons-vue'
 import ToggleInput from './Inputs/ToggleInput.vue'
 import TextInput from './Inputs/TextInput.vue'
+import ModelSelector from './ModelSelector.vue'
 import {
   baseUrl,
   debugMode,
@@ -80,6 +81,13 @@ import {
             />
           </div>
         </div>
+        <div class="mt-4 mb-2">
+          <label class="mb-2 mt-4 block px-2 text-sm font-medium">
+            Model
+          </label>
+          <ModelSelector />
+        </div>
+
       </div>
     </div>
   </aside>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,6 +5,7 @@ import { Message } from './database.ts'
 export type GenerateCompletionRequest = {
   model: string
   prompt?: string
+  images?: string[]
   options?: Record<string, any>
   system?: string
   template?: string
@@ -46,10 +47,22 @@ export type CreateModelResponse = {
   status: string
 }
 
+export interface ModelDetails {
+  parent_model: string
+  format: string
+  family: string
+  families: string[]
+  parameter_size: string
+  quantization_level: string
+}
+
 export type Model = {
   name: string
+  model: string
   modified_at: string
   size: number
+  digest: string
+  details: ModelDetails
 }
 export type ListLocalModelsResponse = {
   models: Model[]

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -15,6 +15,7 @@ export interface Message {
   chatId: number
   role: ChatRole
   content: string
+  image?: string
   meta?: any
   context?: number[]
   createdAt: Date
@@ -28,7 +29,7 @@ class ChatDatabase extends Dexie {
     super('ChatDatabase')
     this.version(2).stores({
       chats: '++id,name,model,createdAt',
-      messages: '++id,chatId,role,content,meta,context,createdAt',
+      messages: '++id,chatId,role,content,image,meta,context,createdAt',
     })
 
     this.chats = this.table('chats')

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -26,7 +26,7 @@ class ChatDatabase extends Dexie {
 
   constructor() {
     super('ChatDatabase')
-    this.version(1).stores({
+    this.version(2).stores({
       chats: '++id,name,model,createdAt',
       messages: '++id,chatId,role,content,meta,context,createdAt',
     })

--- a/src/services/useAI.ts
+++ b/src/services/useAI.ts
@@ -1,3 +1,4 @@
+import { INJECT_IMAGE_KEY } from '../constants.ts';
 import {
   GenerateCompletionCompletedResponse,
   GenerateCompletionPartResponse,
@@ -5,7 +6,20 @@ import {
   Model,
   useApi,
 } from './api.ts'
-import { ref } from 'vue' // Define availableModels outside the function to ensure a shared state.
+import { Ref, inject, ref } from 'vue' // Define availableModels outside the function to ensure a shared state.
+
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => {
+      const result = reader.result as string;
+      const base64Data = result.split(',')[1]; // Remove the beginning part (e.g., "data:image/png;base64,")
+      resolve(base64Data);
+    };
+    reader.onerror = (error) => reject(error);
+  });
+}
 
 // Define availableModels outside the function to ensure a shared state.
 const availableModels = ref<Model[]>([])
@@ -16,12 +30,19 @@ export const useAI = () => {
   const generate = async (
     model: string,
     prompt: string,
+    image?: string,
     context?: number[],
     onMessage?: (data: GenerateCompletionResponse) => void,
     onDone?: (data: GenerateCompletionCompletedResponse) => void,
   ) => {
+    let images: string[] | undefined = undefined;
+
+    if (image) {
+      images = [image];
+    }
+
     await generateCompletion(
-      { model, prompt, context },
+      { model, prompt, context, images },
       (data: GenerateCompletionResponse) => {
         if (!data.done && onMessage) {
           onMessage(data as GenerateCompletionPartResponse)

--- a/src/services/useImageDropzone.ts
+++ b/src/services/useImageDropzone.ts
@@ -17,7 +17,10 @@ export const useImageDropzone = (dropZoneElementRef: Ref<HTMLDivElement | undefi
   })
   
   const onDrop = (files: File[] | null) => {
-    if(!activeModelSupportsClip.value) return;
+    if(!activeModelSupportsClip.value) {
+      alert(`The current model [${activeChat.value?.model}] does not support image input.`);
+      return;
+    };
     imageFile.value = files ? files[0] : null;
   }
   const { isOverDropZone } = useDropZone(dropZoneElementRef, {
@@ -25,7 +28,8 @@ export const useImageDropzone = (dropZoneElementRef: Ref<HTMLDivElement | undefi
     dataTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/bmp']
   })
 
+  const dropZoneIsActive = computed(() => activeModelSupportsClip.value && isOverDropZone.value)
   return {
-    dropZoneIsActive: activeModelSupportsClip && isOverDropZone
+    dropZoneIsActive
   }
 };

--- a/src/services/useImageDropzone.ts
+++ b/src/services/useImageDropzone.ts
@@ -1,0 +1,31 @@
+import { useDropZone } from "@vueuse/core";
+import { Ref, computed, provide, ref } from "vue";
+import { useChats } from "./chat";
+import { useAI } from "./useAI";
+
+export const INJECT_IMAGE_KEY = 'chatImage';
+
+export const useImageDropzone = (dropZoneElementRef: Ref<HTMLDivElement | undefined>) => {
+  const { availableModels } = useAI()
+  const { activeChat } = useChats()
+
+  const imageFile = ref<File | null>(null);
+  provide(INJECT_IMAGE_KEY, imageFile);
+
+  const activeModelSupportsClip = computed(() => {
+    return !!availableModels.value.find(el => activeChat.value?.model === el.name && el.details.families.includes('clip'))
+  })
+  
+  const onDrop = (files: File[] | null) => {
+    if(!activeModelSupportsClip.value) return;
+    imageFile.value = files ? files[0] : null;
+  }
+  const { isOverDropZone } = useDropZone(dropZoneElementRef, {
+    onDrop,
+    dataTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/bmp']
+  })
+
+  return {
+    dropZoneIsActive: activeModelSupportsClip && isOverDropZone
+  }
+};

--- a/src/style.css
+++ b/src/style.css
@@ -16,3 +16,10 @@
 .slide-leave-from {
   transform: translateX(0);
 }
+
+::backdrop {
+  background-color: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
+  opacity: 1;
+}


### PR DESCRIPTION
Hi, I've been using you project to experiment with ollama and it was perfect for my use cases.
But I've encountered that ollama also supports uploading an image for vision models like `llava`, so I've added this simple implementation of allowing to upload an image to the chat so I can experiment with llava too.
It should fix #18 🙂

But I've changed quite a few things so I don't know if you want to merge it like this.

I've removed the top model selector and moved it to the settings component.
Also removing this removed functionality of editing the chat name, so that needs to be placed somewhere too.

Some previews:

![Captura de pantalla 2024-03-09 134407](https://github.com/HelgeSverre/ollama-gui/assets/33053368/2e99d691-d3a3-4d04-894f-ff364a5eb715)

---

![Captura de pantalla 2024-03-09 134514](https://github.com/HelgeSverre/ollama-gui/assets/33053368/fdfe3f68-d8d8-4cd9-b7f0-93b2c060ce79)

---

![Captura de pantalla 2024-03-09 134915](https://github.com/HelgeSverre/ollama-gui/assets/33053368/b24726ef-ac35-4533-8bda-9fec9aea5a7f)
