### PR TITLE
:sparkles: Add config to db to add custom system prompt to chat

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,16 +2,22 @@
 import Sidebar from './components/Sidebar.vue'
 import ChatInput from './components/ChatInput.vue'
 import ChatMessages from './components/ChatMessages.vue'
-import Settings from './components/Settings.vue'
+import SystemPrompt from './components/SystemPrompt.vue'
 import ModelSelector from './components/ModelSelector.vue'
-import { isDarkMode, isSettingsOpen } from './services/appConfig.ts'
+import {
+  currentModel,
+  isDarkMode,
+  isSettingsOpen,
+  isSystemPromptOpen,
+} from './services/appConfig.ts'
 import { onMounted, ref } from 'vue'
 import { useAI } from './services/useAI.ts'
 import { useChats } from './services/chat.ts'
 import TextInput from './components/Inputs/TextInput.vue'
+import Settings from './components/Settings.vue'
 
 const { refreshModels, availableModels } = useAI()
-const { activeChat, renameChat, switchModel, initialize } = useChats()
+const { activeChat, renameChat, switchModel, initialize, hasMessages } = useChats()
 const isEditingChatName = ref(false)
 const editedChatName = ref('')
 
@@ -34,10 +40,8 @@ const confirmRename = () => {
 
 onMounted(() => {
   refreshModels().then(async () => {
-    if (!activeChat.value?.model) {
-      await initialize()
-      await switchModel(availableModels.value[0].name)
-    }
+    await initialize()
+    await switchModel(currentModel.value ?? availableModels.value[0].name)
   })
 })
 </script>
@@ -50,7 +54,17 @@ onMounted(() => {
       <Sidebar />
 
       <div class="mx-auto flex h-[100vh] w-full flex-col">
-        <div class="mx-auto flex h-[100vh] w-full max-w-7xl flex-col gap-4 px-4 pb-4">
+        <div
+          v-if="isSystemPromptOpen"
+          class="mx-auto flex h-[100vh] w-full max-w-7xl flex-col gap-4 px-4 pb-4"
+        >
+          <SystemPrompt />
+        </div>
+
+        <div
+          v-if="!isSystemPromptOpen"
+          class="mx-auto flex h-[100vh] w-full max-w-7xl flex-col gap-4 px-4 pb-4"
+        >
           <div
             class="flex w-full flex-row items-center justify-center gap-4 rounded-b-xl bg-zinc-200 px-4 py-2 dark:bg-zinc-700"
           >
@@ -77,7 +91,7 @@ onMounted(() => {
               </div>
             </div>
 
-            <ModelSelector />
+            <ModelSelector :disabled="hasMessages" />
           </div>
 
           <ChatMessages />

--- a/src/components/ModelSelector.vue
+++ b/src/components/ModelSelector.vue
@@ -3,6 +3,7 @@ import { IconRefresh } from '@tabler/icons-vue'
 import { useChats } from '../services/chat.ts'
 import { useAI } from '../services/useAI.ts'
 import { ref } from 'vue'
+import { currentModel } from '../services/appConfig'
 
 const { activeChat, switchModel, hasMessages } = useChats()
 const { refreshModels, availableModels } = useAI()
@@ -24,14 +25,19 @@ const handleModelChange = (event: Event) => {
   console.log('switch', wip.value)
   switchModel(wip.value)
 }
+
+type Props = {
+  disabled: boolean
+}
+const { disabled } = defineProps<Props>()
 </script>
 
 <template>
   <div class="flex flex-row text-zinc-800 dark:text-zinc-200">
     <div class="inline-flex items-center gap-2">
       <select
-        :disabled="hasMessages"
-        :value="activeChat?.model"
+        :disabled="disabled"
+        :value="activeChat?.model ?? currentModel"
         @change="handleModelChange"
         class="w-full cursor-pointer rounded-lg bg-white py-2 pl-3 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600 disabled:opacity-50 dark:bg-zinc-400 dark:text-zinc-900"
       >
@@ -42,7 +48,7 @@ const handleModelChange = (event: Event) => {
       </select>
 
       <button
-        :disabled="hasMessages"
+        :disabled="disabled"
         title="Refresh available models"
         @click="performRefreshModel"
         class="inline-flex items-center justify-center rounded-lg border-none bg-zinc-200 p-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600 disabled:opacity-50 dark:bg-zinc-400 dark:text-zinc-900"

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -4,9 +4,9 @@ import ToggleInput from './Inputs/ToggleInput.vue'
 import TextInput from './Inputs/TextInput.vue'
 import {
   baseUrl,
+  historyMessageLength,
   debugMode,
   gravatarEmail,
-  isSettingsOpen,
   toggleSettingsPanel,
 } from '../services/appConfig.ts'
 </script>
@@ -39,6 +39,21 @@ import {
         <TextInput label="Base URL" v-model="baseUrl" />
 
         <TextInput label="Gravatar Email" v-model="gravatarEmail" />
+
+        <div>
+          <label for="max-tokens" class="mb-2 mt-4 block px-2 text-sm font-medium">
+            Conversation History Size
+          </label>
+          <input
+            type="number"
+            min="0"
+            max="100"
+            id="chat-history-length"
+            v-model="historyMessageLength"
+            class="block w-full rounded-lg bg-zinc-200 p-2.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-600 dark:bg-zinc-800 dark:placeholder-zinc-400 dark:focus:ring-blue-600"
+            placeholder="2048"
+          />
+        </div>
 
         <div v-if="false">
           <div>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -6,20 +6,32 @@ import {
   IconSun,
   IconTrashX,
   IconUserCircle,
+  IconMessageCode,
 } from '@tabler/icons-vue'
-import { isDarkMode, toggleSettingsPanel } from '../services/appConfig.ts'
-import { useChats } from '../services/chat.ts'
-import { useAI } from '../services/useAI.ts'
 
-const { availableModels } = useAI()
+import {
+  isDarkMode,
+  isSystemPromptOpen,
+  toggleSettingsPanel,
+  toggleSystemPromptPanel,
+} from '../services/appConfig.ts'
+import { useChats } from '../services/chat.ts'
+
 const { sortedChats, activeChat, switchChat, deleteChat, startNewChat, wipeDatabase } =
   useChats()
 
 const onNewChat = () => {
-  return startNewChat(
-    'New chat',
-    activeChat.value?.model ?? availableModels.value[0].name,
-  )
+  checkSystemPromptPanel()
+  return startNewChat('New chat')
+}
+
+const onSwitchChat = (chatId: number) => {
+  checkSystemPromptPanel()
+  return switchChat(chatId)
+}
+
+const checkSystemPromptPanel = () => {
+  isSystemPromptOpen.value = false
 }
 </script>
 
@@ -43,7 +55,7 @@ const onNewChat = () => {
       >
         <button
           v-for="chat in sortedChats"
-          @click="switchChat(chat.id!)"
+          @click="onSwitchChat(chat.id!)"
           @keyup.delete="deleteChat(chat.id!)"
           :class="{
             'bg-zinc-200 dark:bg-zinc-800': activeChat?.id == chat.id,
@@ -95,6 +107,14 @@ const onNewChat = () => {
         >
           <IconUserCircle class="h-6 w-6" />
           User
+        </button>
+        <button
+          @click="toggleSystemPromptPanel"
+          class="flex w-full gap-x-2 rounded-lg px-3 py-2 text-left text-sm font-medium text-zinc-700 transition-colors duration-200 hover:bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-zinc-700 dark:text-zinc-200 dark:placeholder-zinc-400 dark:hover:bg-zinc-800 dark:focus:ring-blue-500"
+        >
+          <IconMessageCode class="h-6 w-6" />
+
+          System prompt
         </button>
         <button
           @click="toggleSettingsPanel"

--- a/src/components/SystemPrompt.vue
+++ b/src/components/SystemPrompt.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { currentModel, useConfig } from '../services/appConfig'
+import { useTextareaAutosize } from '@vueuse/core'
+import { onMounted, ref } from 'vue'
+import ModelSelector from './ModelSelector.vue'
+
+const { setConfig, initializeConfig } = useConfig()
+const { textarea } = useTextareaAutosize()
+const configInput = ref('')
+const defaultConfigInput = ref('')
+import { IconWritingSign } from '@tabler/icons-vue'
+
+onMounted(() => {
+  initialize()
+})
+
+const initialize = () => {
+  initializeConfig(currentModel.value).then(function (configs) {
+    configInput.value = configs?.modelConfig?.systemPrompt ?? ''
+    defaultConfigInput.value = configs?.defaultConfig?.systemPrompt ?? ''
+  })
+}
+
+const onSubmit = () => {
+  const model = currentModel.value
+  setConfig({
+    model: 'default',
+    systemPrompt: defaultConfigInput.value.trim(),
+    createdAt: new Date(),
+  })
+  if (model) {
+    setConfig({
+      model: model,
+      systemPrompt: configInput.value.trim(),
+      createdAt: new Date(),
+    })
+  }
+  alert('Saved !')
+}
+
+const shouldSubmit = ({ key, shiftKey }: KeyboardEvent): boolean => {
+  return key === 'Enter' && !shiftKey
+}
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (shouldSubmit(event)) {
+    event.preventDefault()
+    onSubmit()
+  }
+}
+</script>
+
+<template>
+  <aside>
+    <div
+      class="flex w-full flex-row items-center justify-center gap-4 rounded-b-xl bg-zinc-200 px-4 py-2 dark:bg-zinc-700"
+    >
+      <div class="mr-auto flex h-full items-center">
+        <div>
+          <span
+            class="block h-full rounded border-none p-2 text-zinc-700 decoration-gray-400 decoration-dashed outline-none hover:underline focus:ring-2 focus:ring-blue-600 dark:text-zinc-100 dark:focus:ring-blue-600"
+          >
+            System prompt
+          </span>
+        </div>
+      </div>
+      <ModelSelector :disabled="false" @change="initialize" />
+    </div>
+
+    <div
+      class="text-md mb-[20px] mt-[30px] gap-4 rounded-xl px-1 py-2 font-medium leading-none text-zinc-900 dark:text-zinc-200"
+    >
+      <p class="mb-[20px]">
+        <b>Custom Instructions</b>
+      </p>
+      <p>
+        What would you like the current model to know about you to provide better
+        responses?
+      </p>
+    </div>
+    <form class="mt-2" @submit.prevent="onSubmit">
+      <div
+        class="flex-row items-center justify-center gap-4 rounded-xl bg-zinc-200 px-2 py-2 dark:bg-zinc-700"
+      >
+        <div class="h-full items-center">
+          <div>
+            <textarea
+              ref="textarea"
+              v-model="configInput"
+              class="p-t-4 p-b-4 block max-h-[200px] min-h-[150px] w-full resize-none rounded-xl border-none bg-zinc-100 px-2 py-2 pr-20 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-base dark:bg-zinc-700 dark:text-zinc-200 dark:placeholder-zinc-400 dark:focus:ring-blue-500"
+              @keydown="onKeydown"
+            ></textarea>
+          </div>
+        </div>
+      </div>
+    </form>
+
+    <div
+      class="text-md mb-[20px] mt-[30px] gap-4 rounded-xl px-1 py-2 font-medium leading-none text-zinc-900 dark:text-zinc-200"
+    >
+      <p class="mb-[20px]">
+        <b>Default Instructions</b>
+      </p>
+      <p>
+        What would you like all models to know about you to provide better responses? This
+        prompt will be applied for all models by default even if you configure custom
+        prompt for a model
+      </p>
+    </div>
+    <form class="mt-2" @submit.prevent="onSubmit">
+      <div
+        class="flex-row items-center justify-center gap-4 rounded-xl bg-zinc-200 px-2 px-2 py-2 py-2 dark:bg-zinc-700"
+      >
+        <div class="h-full items-center">
+          <div>
+            <textarea
+              ref="textarea"
+              v-model="defaultConfigInput"
+              class="p-t-4 p-b-4 block max-h-[200px] min-h-[150px] w-full resize-none rounded-xl border-none bg-zinc-100 px-1 py-2 pr-20 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-base dark:bg-zinc-700 dark:text-zinc-200 dark:placeholder-zinc-400 dark:focus:ring-blue-500"
+              @keydown="onKeydown"
+            ></textarea>
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        class="right mt-[20px] flex gap-x-2 rounded-lg px-3 py-2 text-sm font-medium text-zinc-700 transition-colors duration-200 hover:bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-zinc-700 dark:text-zinc-200 dark:placeholder-zinc-400 dark:hover:bg-zinc-800 dark:focus:ring-blue-500"
+      >
+        <IconWritingSign class="h-6 w-6" />
+        Save
+      </button>
+    </form>
+  </aside>
+</template>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,40 +2,37 @@ import { ref } from 'vue'
 import { baseUrl } from './appConfig.ts'
 import { Message } from './database.ts'
 
-export type GenerateCompletionRequest = {
+export type ChatRequest = {
   model: string
-  prompt?: string
-  options?: Record<string, any>
-  system?: string
-  template?: string
-  context?: number[]
+  messages?: Message[]
 }
 
-export type GenerateCompletionCompletedResponse = {
+export type ChatMessage = {
+  role: string
+  content: string
+}
+
+export type ChatCompletedResponse = {
   model: string
   created_at: string
-  response: string
+  message: ChatMessage
   done: boolean
   total_duration: number
   load_duration: number
-  sample_count: number
-  sample_duration: number
   prompt_eval_count: number
   prompt_eval_duration: number
   eval_count: number
   eval_duration: number
-  context: number[]
 }
-export type GenerateCompletionPartResponse = {
+
+export type ChatPartResponse = {
   model: string
   created_at: string
-  response: string
+  message: ChatMessage
   done: boolean
 }
 
-export type GenerateCompletionResponse =
-  | GenerateCompletionCompletedResponse
-  | GenerateCompletionPartResponse
+export type ChatResponse = ChatCompletedResponse | ChatPartResponse
 
 export type CreateModelRequest = {
   name: string
@@ -123,11 +120,11 @@ const signal = ref<AbortSignal>(abortController.value.signal)
 export const useApi = () => {
   const error = ref(null)
 
-  const generateCompletion = async (
-    request: GenerateCompletionRequest,
-    onDataReceived: (data: GenerateCompletionResponse) => void,
-  ): Promise<GenerateCompletionResponse[]> => {
-    const res = await fetch(getApiUrl('/generate'), {
+  const generateChat = async (
+    request: ChatRequest,
+    onDataReceived: (data: any) => void,
+  ): Promise<any[]> => {
+    const res = await fetch(getApiUrl('/chat'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -141,7 +138,7 @@ export const useApi = () => {
     }
 
     const reader = res.body?.getReader()
-    let results: GenerateCompletionResponse[] = []
+    let results: ChatResponse[] = []
 
     if (reader) {
       while (true) {
@@ -151,7 +148,7 @@ export const useApi = () => {
         }
 
         const chunk = new TextDecoder().decode(value)
-        const parsedChunk: GenerateCompletionPartResponse = JSON.parse(chunk)
+        const parsedChunk: ChatPartResponse = JSON.parse(chunk)
 
         onDataReceived(parsedChunk)
         results.push(parsedChunk)
@@ -280,7 +277,7 @@ export const useApi = () => {
 
   return {
     error,
-    generateCompletion,
+    generateChat,
     createModel,
     listLocalModels,
     showModelInformation,

--- a/src/services/appConfig.ts
+++ b/src/services/appConfig.ts
@@ -1,11 +1,78 @@
 import { useLocalStorage } from '@vueuse/core'
 import gravatarUrl from 'gravatar-url'
 import { computed } from 'vue'
+import { Config, db } from './database'
 
+export const currentModel = useLocalStorage('currentModel', 'none')
 export const gravatarEmail = useLocalStorage('gravatarEmail', 'helge.sverre@gmail.com')
+export const historyMessageLength = useLocalStorage('historyMessageLength', 10)
 export const avatarUrl = computed(() => gravatarUrl(gravatarEmail.value, { size: 200 }))
 export const debugMode = useLocalStorage('debug', false)
 export const baseUrl = useLocalStorage('baseUrl', 'http://localhost:11434/api')
 export const isDarkMode = useLocalStorage('darkMode', true)
 export const isSettingsOpen = useLocalStorage('settingsPanelOpen', true)
+export const isSystemPromptOpen = useLocalStorage('systemPromptOpen', true)
 export const toggleSettingsPanel = () => (isSettingsOpen.value = !isSettingsOpen.value)
+export const toggleSystemPromptPanel = () =>
+  (isSystemPromptOpen.value = !isSystemPromptOpen.value)
+
+// Database Layer
+export const configDbLayer = {
+  async getConfig(model: string) {
+    const filteredConfig = await db.config.where('model').equals(model).limit(1)
+    return filteredConfig.first()
+  },
+
+  async getCurrentConfig(model: string) {
+    let config = await this.getConfig(model)
+    if (!config?.systemPrompt) {
+      config = await this.getConfig('default')
+    }
+    return config
+  },
+
+  async setConfig(config: Config) {
+    await db.config.put(config)
+  },
+
+  async clearConfig() {
+    return db.config.clear()
+  },
+}
+
+export function useConfig() {
+  const setConfig = async (newConfig: Config) => {
+    newConfig.id = await generateIdFromModel(newConfig.model)
+    await configDbLayer.setConfig(newConfig)
+  }
+
+  const getCurrentSystemMessage = async () => {
+    let config = await configDbLayer.getCurrentConfig(currentModel.value)
+    return config?.systemPrompt ?? null
+  }
+
+  const generateIdFromModel = async (model: string): Promise<number> => {
+    let hash = 0
+    for (let i = 0; i < model.length; i++) {
+      hash += model.charCodeAt(i)
+    }
+    return hash
+  }
+
+  const initializeConfig = async (model: string) => {
+    try {
+      const modelConfig = await configDbLayer.getConfig(model)
+      const defaultConfig = await configDbLayer.getConfig('default')
+      return { modelConfig: modelConfig, defaultConfig: defaultConfig }
+    } catch (error) {
+      console.error('Failed to initialize config:', error)
+    }
+    return null
+  }
+
+  return {
+    initializeConfig,
+    setConfig,
+    getCurrentSystemMessage,
+  }
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3,6 +3,13 @@ import Dexie from 'dexie'
 
 export type ChatRole = 'user' | 'assistant' | 'system'
 
+export interface Config {
+  id?: number
+  model: string
+  systemPrompt: string
+  createdAt: Date
+}
+
 export interface Chat {
   id?: number
   name: string
@@ -23,16 +30,19 @@ export interface Message {
 class ChatDatabase extends Dexie {
   chats: Dexie.Table<Chat, number>
   messages: Dexie.Table<Message, number>
+  config: Dexie.Table<Config, number>
 
   constructor() {
     super('ChatDatabase')
-    this.version(1).stores({
+    this.version(10).stores({
       chats: '++id,name,model,createdAt',
       messages: '++id,chatId,role,content,meta,context,createdAt',
+      config: '++id,model,systemPrompt,createdAt',
     })
 
     this.chats = this.table('chats')
     this.messages = this.table('messages')
+    this.config = this.table('config')
   }
 }
 


### PR DESCRIPTION
I made this PR so I could configure a system prompt for chat:

1. Ability to add a default system prompt that will apply to all models if no system prompt is defined for this model
2. Ability to add a specific system prompt for each model

I also make code to save the loaded model to localStorage (in order to keep the value in the event of a page refresh).

I also modified the API call for chat. Indeed, by calling the "/generate" route, we do not have the entire context of the conversation. You have to call the "/chat" route and go through the list of previous messages to have a real conversation.