### PR TITLE
fix: use the user's system locale for date formatting

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -70,7 +70,7 @@ const checkSystemPromptPanel = () => {
           </span>
           <span class="text-xs leading-none text-zinc-500 dark:text-zinc-400">
             {{
-              chat.createdAt.toLocaleDateString('no', {
+              chat.createdAt.toLocaleDateString(undefined, {
                 day: '2-digit',
                 month: 'short',
                 weekday: 'long',


### PR DESCRIPTION
fix issue #26 

Instead of hardcoding Norwegian locale, use the user's system locale for date formatting