### PR TITLE
Fix Chinese input method bug

### DIFF
--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -9,6 +9,7 @@ const { addUserMessage, abort, hasActiveChat } = useChats()
 
 const isInputValid = computed<boolean>(() => !!userInput.value.trim())
 const isAiResponding = ref(false)
+const flag = ref(true)
 
 const onSubmit = () => {
   if (isAiResponding.value) {
@@ -31,7 +32,7 @@ const shouldSubmit = ({ key, shiftKey }: KeyboardEvent): boolean => {
 }
 
 const onKeydown = (event: KeyboardEvent) => {
-  if (shouldSubmit(event)) {
+  if (shouldSubmit(event) && flag.value) {
     // Pressing enter while the ai is responding should not abort the request
     if (isAiResponding.value) {
       return
@@ -40,6 +41,14 @@ const onKeydown = (event: KeyboardEvent) => {
     event.preventDefault()
     onSubmit()
   }
+}
+
+const handleCompositionStart = () => {
+  flag.value = false
+}
+
+const handleCompositionEnd = () => {
+  flag.value = true
 }
 </script>
 
@@ -52,6 +61,8 @@ const onKeydown = (event: KeyboardEvent) => {
         class="block max-h-[500px] w-full resize-none rounded-xl border-none bg-zinc-100 p-4 pl-4 pr-20 text-sm text-zinc-900 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-base dark:bg-zinc-700 dark:text-zinc-200 dark:placeholder-zinc-400 dark:focus:ring-blue-500"
         placeholder="Enter your prompt"
         @keydown="onKeydown"
+        @compositionstart="handleCompositionStart"
+        @compositionend="handleCompositionEnd"
       ></textarea>
       <button
         type="submit"


### PR DESCRIPTION
#### Description
When using the Chinese input method, pressing the Enter key during input caused the input content to be lost. This issue occurred because pressing Enter during Chinese input directly submitted the input content instead of waiting for the input to complete.

#### Solution
By adding a `flag` variable to control whether submission is allowed and updating this variable in the `compositionstart` and `compositionend` events, we ensure that the input content is only submitted after the Chinese input is complete.

#### Changes
- Added a `flag` variable to control whether submission is allowed.
- Checked the `flag` variable in the `keydown` event handler to ensure that the input content is not submitted during Chinese input.
- Updated the `flag` variable in the `compositionstart` and `compositionend` event handlers.

#### Verification
1. Input some text using the Chinese input method.
2. Press the Enter key to ensure the input content does not get lost.
3. Wait for the input to complete, then press the Enter key again to ensure the input content is correctly submitted.
