### PR TITLE
Add Docker Image To GitHub Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,95 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ '*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ OLLAMA_ORIGINS=https://ollama-gui.vercel.app ollama serve
 ### Docker Deployment
 
 ```bash
+# Pull and run the latest image
+docker run -p 8080:80 ghcr.io/helgesverre/ollama-gui:main
+
+# Access at http://localhost:8080
+```
+
+Or build the image locally, and run it:
+
+```bash
 # Build the image
 docker build -t ollama-gui .
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ OLLAMA_ORIGINS=https://ollama-gui.vercel.app ollama serve
 
 ```bash
 # Pull and run the latest image
-docker run -p 8080:80 ghcr.io/helgesverre/ollama-gui:main
+docker run -d -p 8080:80 ghcr.io/helgesverre/ollama-gui:main
 
 # Access at http://localhost:8080
 ```
@@ -71,7 +71,7 @@ Or build the image locally, and run it:
 docker build -t ollama-gui .
 
 # Run the container
-docker run -p 8080:80 ollama-gui
+docker run -d -p 8080:80 ollama-gui
 
 # Access at http://localhost:8080
 ```


### PR DESCRIPTION
Hello,
I have noticed that this repository builds a docker image.

But to use that image, I am required to:
- Clone the git repository
- Build the image locally
- Run the image

Instead, we could ease the process, by pre-building the image, and pushing it to a public docker registry, such as the `ghcr` (GitHub registry made for the repository).

### Changes

- I have added a simple GitHub Actions `.yml` file, for automatically building & pushing the docker image to the `ghcr` docker registry of this repository.
- I have updated the `README.md` with the changes.
- I have noticed that the `docker run` command, in the `README.md` runs the container without "detached" mode, which is not commonly used. The better use case is to run the container with "detached" mode. So I updated the `README.md` to run the commands with "detached" mode (`-d`).


