### PR TITLE
feat: implement LaTeX math rendering in markdown component

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
       rel="stylesheet"
     />
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css"
+      integrity="sha384-zh0CIslj+VczCZtlzBcjt5ppRcsAmDnRem7ESsYwWwg3m/OaJ2l4x7YBZl9Kxxib" crossorigin="anonymous">
+
     <title>Ollama GUI</title>
   </head>
   <body class="h-full font-sans antialiased">

--- a/index.html
+++ b/index.html
@@ -21,13 +21,10 @@
       rel="stylesheet"
     />
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css"
-      integrity="sha384-zh0CIslj+VczCZtlzBcjt5ppRcsAmDnRem7ESsYwWwg3m/OaJ2l4x7YBZl9Kxxib" crossorigin="anonymous">
-
     <title>Ollama GUI</title>
   </head>
   <body class="h-full font-sans antialiased">
-    <div id="app"></div>
+     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tabler/icons-vue": "^2.38.0",
     "@tailwindcss/typography": "^0.5.10",
     "@types/markdown-it": "^13.0.7",
+    "@vscode/markdown-it-katex": "^1.1.1",
     "@vueuse/core": "^10.5.0",
     "autoprefixer": "^10.4.16",
     "date-fns": "^3.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -70,7 +70,7 @@ onMounted(() => {
 
         <div
           v-if="!isSystemPromptOpen"
-          class="mx-auto flex h-screen w-full max-w-7xl flex-col gap-4 px-4 pb-4"
+          class="mx-auto flex h-screen w-full max-w-7xl flex-col gap-4 px-4 pb-4 overflow-hidden relative"
         >
           <div
             class="flex w-full flex-row items-center justify-center gap-4 rounded-b-xl bg-gray-100 px-4 py-2 dark:bg-gray-800"

--- a/src/components/ChatMessages.vue
+++ b/src/components/ChatMessages.vue
@@ -52,7 +52,7 @@ const visibleMessages = computed(() =>
 <template>
   <div
     ref="chatElement"
-    class="flex-1 overflow-y-auto scroll-smooth rounded-xl p-4 text-sm leading-6 text-gray-900 dark:text-gray-100 sm:text-base sm:leading-7"
+    class="flex-1 overflow-y-auto scroll-smooth rounded-xl p-4 text-sm leading-6 text-gray-900 dark:text-gray-100 sm:text-base sm:leading-7 relative h-full"
   >
     <ChatMessage v-for="message in visibleMessages" :message="message" />
   </div>

--- a/src/components/Markdown.ts
+++ b/src/components/Markdown.ts
@@ -1,6 +1,8 @@
 import { Component, computed, defineComponent, h, ref } from 'vue'
 import highlightjs from 'markdown-it-highlightjs'
 import markdownit from 'markdown-it'
+import markdownItKatex from '@vscode/markdown-it-katex'
+import { preprocessLatex } from '../utils'
 
 const Markdown: Component = defineComponent({
   props: {
@@ -12,13 +14,18 @@ const Markdown: Component = defineComponent({
   setup(props) {
     const md = ref<markdownit>(markdownit())
 
+    md.value.use(markdownItKatex)
+
     md.value.use(highlightjs, {
       inline: true,
       auto: true,
       ignoreIllegals: true,
     })
 
-    const content = computed(() => md.value.render(props.source))
+    const content = computed(() => {
+      const preprocessed = preprocessLatex(props.source)
+      return md.value.render(preprocessed)
+    })
 
     return () => h('div', { innerHTML: content.value })
   },

--- a/src/components/Messages/AiMessage.vue
+++ b/src/components/Messages/AiMessage.vue
@@ -25,7 +25,7 @@ const thought = computed(() => {
 </script>
 
 <template>
-  <div class="flex rounded-xl bg-gray-100 px-2 py-6 dark:bg-gray-800 sm:px-4">
+  <div class="flex rounded-xl bg-gray-100 px-2 py-6 dark:bg-gray-800 sm:px-4 ">
     <img
       class="mr-2 flex size-10 aspect-square rounded-full border border-gray-200 bg-white object-contain sm:mr-4"
       :src="logo"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,28 @@ const nanoToHHMMSS = (nanoSeconds: bigint): string => {
   const milliseconds = Number(nanoSeconds / BigInt(1e6))
   return format(new Date(milliseconds), 'HH:mm:ss')
 }
+
+/**
+ * Preprocesses LaTeX style math delimiters into KaTeX compatible syntax.
+ * 
+ * This function converts LaTeX-style delimiters to the dollar sign format 
+ * expected by KaTeX and markdown-it-katex:
+ * - Converts \[...\] (LaTeX display math) to $$...$$ (KaTeX display math)
+ * - Converts \(...\) (LaTeX inline math) to $...$ (KaTeX inline math)
+ * 
+ * This preprocessing is necessary because markdown-it typically interprets
+ * backslashes as escape characters, causing LaTeX delimiters to be removed
+ * during rendering. By converting to dollar sign notation, we ensure proper
+ * math rendering while preserving the original LaTeX content.
+ * 
+ * @param source - The original markdown string containing LaTeX math expressions
+ * @returns The processed string with LaTeX delimiters converted to KaTeX format
+ */
+export const preprocessLatex = (source: string): string => {
+  let processed = source.replace(/\\\[/g, '$$')
+  processed = processed.replace(/\\\]/g, '$$')
+  processed = processed.replace(/\\\(/g, '$')
+  processed = processed.replace(/\\\)/g, '$')
+  
+  return processed
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,6 +388,13 @@
     path-browserify "^1.0.1"
     vscode-uri "^3.0.8"
 
+"@vscode/markdown-it-katex@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@vscode/markdown-it-katex/-/markdown-it-katex-1.1.1.tgz#85b884df98b9a377168451660cf95eaf9e70aaee"
+  integrity sha512-3KTlbsRBPJQLE2YmLL7K6nunTlU+W9T5+FjfNdWuIUKgxSS6HWLQHaO3L4MkJi7z7MpIPpY+g4N+cWNBPE/MSA==
+  dependencies:
+    katex "^0.16.4"
+
 "@vue/compiler-core@3.5.13":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.13.tgz#b0ae6c4347f60c03e849a05d34e5bf747c9bda05"
@@ -655,6 +662,11 @@ commander@^4.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
+commander@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
 cross-spawn@^7.0.0:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -916,6 +928,13 @@ jiti@^1.21.6:
   version "1.21.6"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
   integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
+
+katex@^0.16.4:
+  version "0.16.21"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.21.tgz#8f63c659e931b210139691f2cc7bb35166b792a3"
+  integrity sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==
+  dependencies:
+    commander "^8.3.0"
 
 lilconfig@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Added support for mathematical expressions in markdown content by:
- Integrating @vscode/markdown-it-katex plugin
- Creating preprocessLatex function to handle LaTeX-style delimiters
- Converting traditional LaTeX notation `\[...\]` and `\(...\)` to KaTeX-compatible format `$$...$$` and `$...$`

This enhancement allows proper rendering of complex mathematical formulas within markdown documentation.

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/d1556810-b389-42fa-ab34-eec05dc53cf3" />