### PR TITLE
feat: add configurable locale for date/time formatting

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -11,6 +11,7 @@ import {
   showSystem,
   gravatarEmail,
   toggleSettingsPanel,
+  locale,
 } from '../services/appConfig.ts'
 import { useChats } from '../services/chat.ts'
 
@@ -22,6 +23,29 @@ const confirmWipe = () => {
     wipeDatabase()
   }
 }
+
+// Common locale options
+const localeOptions = [
+  { value: 'auto', label: 'Auto (System Default)' },
+  { value: 'en-US', label: 'English (US)' },
+  { value: 'en-GB', label: 'English (UK)' },
+  { value: 'de-DE', label: 'Deutsch (Germany)' },
+  { value: 'es-ES', label: 'Español (Spain)' },
+  { value: 'fr-FR', label: 'Français (France)' },
+  { value: 'it-IT', label: 'Italiano (Italy)' },
+  { value: 'ja-JP', label: '日本語 (Japan)' },
+  { value: 'ko-KR', label: '한국어 (Korea)' },
+  { value: 'nb-NO', label: 'Norsk (Norway)' },
+  { value: 'nl-NL', label: 'Nederlands (Netherlands)' },
+  { value: 'pl-PL', label: 'Polski (Poland)' },
+  { value: 'pt-BR', label: 'Português (Brazil)' },
+  { value: 'pt-PT', label: 'Português (Portugal)' },
+  { value: 'ru-RU', label: 'Русский (Russia)' },
+  { value: 'sv-SE', label: 'Svenska (Sweden)' },
+  { value: 'tr-TR', label: 'Türkçe (Turkey)' },
+  { value: 'zh-CN', label: '中文 (China)' },
+  { value: 'zh-TW', label: '中文 (Taiwan)' },
+]
 </script>
 
 <template>
@@ -53,6 +77,21 @@ const confirmWipe = () => {
         <TextInput id="base-url" label="Base URL" v-model="baseUrl" />
 
         <TextInput id="gravatar-email" label="Gravatar Email" v-model="gravatarEmail" />
+
+        <div>
+          <label for="locale-select" class="mb-2 mt-4 block px-2 text-sm font-medium">
+            Date/Time Locale
+          </label>
+          <select
+            id="locale-select"
+            v-model="locale"
+            class="block w-full rounded-lg bg-gray-100 p-2.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-600 dark:bg-gray-800 dark:placeholder-gray-300 dark:focus:ring-blue-600"
+          >
+            <option v-for="option in localeOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
+          </select>
+        </div>
 
         <div>
           <label for="chat-history-length" class="mb-2 mt-4 block px-2 text-sm font-medium">

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -85,7 +85,7 @@ const localeOptions = [
           <select
             id="locale-select"
             v-model="locale"
-            class="block w-full rounded-lg bg-gray-100 p-2.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-600 dark:bg-gray-800 dark:placeholder-gray-300 dark:focus:ring-blue-600"
+            class="block w-full rounded-lg border border-gray-300 bg-gray-100 p-2.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:placeholder-gray-300 dark:focus:ring-blue-600"
           >
             <option v-for="option in localeOptions" :key="option.value" :value="option.value">
               {{ option.label }}

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -14,8 +14,10 @@ import {
   isSystemPromptOpen,
   toggleSettingsPanel,
   toggleSystemPromptPanel,
+  getEffectiveLocale,
 } from '../services/appConfig.ts'
 import { useChats } from '../services/chat.ts'
+import { computed } from 'vue'
 
 const { sortedChats, activeChat, switchChat, deleteChat, startNewChat } =
   useChats()
@@ -34,7 +36,7 @@ const checkSystemPromptPanel = () => {
   isSystemPromptOpen.value = false
 }
 
-const lang = navigator.language
+const lang = computed(() => getEffectiveLocale())
 </script>
 
 <template>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -14,10 +14,9 @@ import {
   isSystemPromptOpen,
   toggleSettingsPanel,
   toggleSystemPromptPanel,
-  getEffectiveLocale,
+  effectiveLocale,
 } from '../services/appConfig.ts'
 import { useChats } from '../services/chat.ts'
-import { computed } from 'vue'
 
 const { sortedChats, activeChat, switchChat, deleteChat, startNewChat } =
   useChats()
@@ -36,7 +35,7 @@ const checkSystemPromptPanel = () => {
   isSystemPromptOpen.value = false
 }
 
-const lang = computed(() => getEffectiveLocale())
+const lang = effectiveLocale
 </script>
 
 <template>

--- a/src/services/appConfig.ts
+++ b/src/services/appConfig.ts
@@ -16,9 +16,15 @@ export const baseUrl = useLocalStorage('baseUrl', 'http://localhost:11434/api')
 export const isDarkMode = useLocalStorage('darkMode', true)
 export const isSettingsOpen = useLocalStorage('settingsPanelOpen', true)
 export const isSystemPromptOpen = useLocalStorage('systemPromptOpen', false)
+export const locale = useLocalStorage('locale', 'auto')
 export const toggleSettingsPanel = () => (isSettingsOpen.value = !isSettingsOpen.value)
 export const toggleSystemPromptPanel = () =>
   (isSystemPromptOpen.value = !isSystemPromptOpen.value)
+
+// Get the effective locale for date formatting
+export const getEffectiveLocale = () => {
+  return locale.value === 'auto' ? navigator.language : locale.value
+}
 
 // Database Layer
 export const configDbLayer = {

--- a/src/services/appConfig.ts
+++ b/src/services/appConfig.ts
@@ -21,10 +21,10 @@ export const toggleSettingsPanel = () => (isSettingsOpen.value = !isSettingsOpen
 export const toggleSystemPromptPanel = () =>
   (isSystemPromptOpen.value = !isSystemPromptOpen.value)
 
-// Get the effective locale for date formatting
-export const getEffectiveLocale = () => {
-  return locale.value === 'auto' ? navigator.language : locale.value
-}
+// Effective locale for date formatting (resolves 'auto' to system locale)
+export const effectiveLocale = computed(() =>
+  locale.value === 'auto' ? navigator.language : locale.value
+)
 
 // Database Layer
 export const configDbLayer = {


### PR DESCRIPTION
## Summary

This PR addresses issue #26 by making the date/time locale configurable instead of hardcoded. Users can now choose their preferred locale from a dropdown in Settings, or use the default "Auto" option which inherits the system locale.

## Changes Made

**Added locale configuration in `src/services/appConfig.ts`:**
- New locale setting stored in localStorage (defaults to 'auto')
- New `getEffectiveLocale()` helper function that returns the configured locale or system locale when set to 'auto'

**Updated `src/components/Sidebar.vue`:**
- Changed from using static `navigator.language` to reactive computed locale
- Dates now update immediately when locale setting changes

**Enhanced `src/components/Settings.vue`:**
- Added locale dropdown selector with 18 common locale options
- Includes languages: English (US/UK), German, Spanish, French, Italian, Japanese, Korean, Norwegian, Dutch, Polish, Portuguese (Brazil/Portugal), Russian, Swedish, Turkish, and Chinese (China/Taiwan)

## Key Features
- **Backward compatible**: Default "Auto" setting uses the browser's system locale, maintaining existing behavior
- **Persistent**: User preference is saved to localStorage
- **Reactive**: Date formats update immediately when the locale setting changes
- **Comprehensive**: Provides a wide selection of commonly used locales

## Comparison with PR #34
While PR #34 only uses the system locale directly, this implementation provides full configurability as requested in the issue, allowing users to override their system settings if desired.

Fixes #26

## Test Plan
- Build succeeds with TypeScript type checking
- Verify default "Auto" option uses system locale
- Change locale in Settings and verify date format updates in Sidebar
- Verify locale preference persists after page reload
- Test with different locale options (e.g., en-US, de-DE, ja-JP)
- Verify dark mode styling on locale dropdown